### PR TITLE
Activate script for blog.github.com

### DIFF
--- a/github-dark-script.user.js
+++ b/github-dark-script.user.js
@@ -5,7 +5,7 @@
 // @license     MIT
 // @author      StylishThemes
 // @namespace   https://github.com/StylishThemes
-// @include     /^https?://((gist|guides|help|raw|status|developer)\.)?github\.com/((?!generated_pages\/preview).)*$/
+// @include     /^https?://((gist|guides|help|raw|status|developer|blog)\.)?github\.com/((?!generated_pages\/preview).)*$/
 // @include     /^https://*.githubusercontent.com/*$/
 // @include     /^https://*graphql-explorer.githubapp.com/*$/
 // @run-at      document-start


### PR DESCRIPTION
Github Dark seems to be already working well for the GitHub Blog.

Example url: https://blog.github.com/2014-09-22-third-annual-data-challenge-winners/

Without Github Dark:
![selection_187](https://user-images.githubusercontent.com/459631/38337301-0af63376-3865-11e8-8c06-a6dea5e560ea.png)

With Github Dark:
![selection_188](https://user-images.githubusercontent.com/459631/38337311-1505a3a6-3865-11e8-861e-736c76b89f08.png)
