### PR TITLE
Update url regex to match usercss

### DIFF
--- a/github-dark-script.user.js
+++ b/github-dark-script.user.js
@@ -5,7 +5,7 @@
 // @license     MIT
 // @author      StylishThemes
 // @namespace   https://github.com/StylishThemes
-// @include     /^https?://((blog|gist|guides|help|raw|status|developer)\.)?github\.com/((?!generated_pages\/preview).)*$/
+// @include     /^https?://((gist|guides|help|launch-editor|raw|resources|status|developer)\.)?github\.com/((?!generated_pages\/preview).)*$/
 // @include     https://*.githubusercontent.com/*
 // @include     https://*graphql-explorer.githubapp.com/*
 // @run-at      document-start


### PR DESCRIPTION
Wanted to PR this because I'm wondering how the other `@-moz-document` elements should be handled now. The script seems to remove the main one and uses this `@include` in its place, but what about the others?