### PR TITLE
Add homepageURL to metadata block

### DIFF
--- a/github-dark-script.user.js
+++ b/github-dark-script.user.js
@@ -30,6 +30,7 @@
 // @icon        https://avatars3.githubusercontent.com/u/6145677?v=3&s=200
 // @updateURL   https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-dark-script.user.js
 // @downloadURL https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-dark-script.user.js
+// @homepageURL https://github.com/StylishThemes/GitHub-Dark-Script
 // ==/UserScript==
 /* global jscolor */
 (async () => {

--- a/github-script-code-wrap.user.js
+++ b/github-script-code-wrap.user.js
@@ -16,6 +16,7 @@
 // @icon        https://avatars3.githubusercontent.com/u/6145677?v=3&s=200
 // @updateURL   https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-code-wrap.user.js
 // @downloadURL https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-code-wrap.user.js
+// @homepageURL https://github.com/StylishThemes/GitHub-Dark-Script
 // ==/UserScript==
 (() => {
   "use strict";

--- a/github-script-diff-toggle.user.js
+++ b/github-script-diff-toggle.user.js
@@ -15,6 +15,7 @@
 // @icon        https://avatars3.githubusercontent.com/u/6145677?v=3&s=200
 // @updateURL   https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-diff-toggle.user.js
 // @downloadURL https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-diff-toggle.user.js
+// @homepageURL https://github.com/StylishThemes/GitHub-Dark-Script
 // ==/UserScript==
 (() => {
   "use strict";

--- a/github-script-make-tooltips.user.js
+++ b/github-script-make-tooltips.user.js
@@ -11,6 +11,7 @@
 // @icon        https://avatars3.githubusercontent.com/u/6145677?v=3&s=200
 // @updateURL   https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-make-tooltips.user.js
 // @downloadURL https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-make-tooltips.user.js
+// @homepageURL https://github.com/StylishThemes/GitHub-Dark-Script
 // ==/UserScript==
 (() => {
   "use strict";

--- a/github-script-monospace-toggle.user.js
+++ b/github-script-monospace-toggle.user.js
@@ -12,6 +12,7 @@
 // @icon        https://avatars3.githubusercontent.com/u/6145677?v=3&s=200
 // @updateURL   https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-monospace-toggle.user.js
 // @downloadURL https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Script/master/github-script-monospace-toggle.user.js
+// @homepageURL https://github.com/StylishThemes/GitHub-Dark-Script
 // ==/UserScript==
 (() => {
   "use strict";


### PR DESCRIPTION
I noticed that after installing the style from Github, the home page link for this style in the Violentmonkey dashboard page defaults to `about:blank`. For the sake of completeness, I thought it would be good to add [`homepageURL`](https://violentmonkey.github.io/api/metadata-block/#homepageurl) to the metadata block. 

<img width="500" alt="link" src="https://user-images.githubusercontent.com/43548622/72768575-afea4100-3bac-11ea-9b5c-c23f77e8e4c7.png">
